### PR TITLE
Add Name property and pipeline support.

### DIFF
--- a/Tests/sthArgumentCompleter.tests.ps1
+++ b/Tests/sthArgumentCompleter.tests.ps1
@@ -99,6 +99,12 @@ Describe "sthArgumentCompleter" {
             Get-CustomArgumentCompleter | Should -HaveCount 4
         }
 
+        It "Should accept Custom Argument Completers to delete by pipeline" {
+            Get-CustomArgumentCompleter -Name CommandOne:ParameterTwo | Remove-CustomArgumentCompleter
+            Get-CustomArgumentCompleter -Name CommandOne:ParameterTwo | Should -BeNullOrEmpty
+            Get-CustomArgumentCompleter | Should -HaveCount 3
+        }
+
         It "Should return an error when Custom Argument Completer doesn't exist" {
             { Remove-CustomArgumentCompleter -Name CommandOne:ParameterOne -ErrorAction Stop } | Should -Throw -ErrorId 'ArgumentError'
         }
@@ -109,6 +115,12 @@ Describe "sthArgumentCompleter" {
         It "Should remove Native Argument Completer by name" {
             Remove-NativeArgumentCompleter -Name CommandThree
             Get-NativeArgumentCompleter | Should -HaveCount 2
+        }
+
+        It "Should accept Native Argument Completers to delete by pipeline" {
+            Get-NativeArgumentCompleter -Name CommandFour | Remove-NativeArgumentCompleter
+            Get-NativeArgumentCompleter -Name CommandFour | Should -BeNullOrEmpty
+            Get-NativeArgumentCompleter | Should -HaveCount 1
         }
 
         It "Should return an error when Native Argument Completer doesn't exist" {

--- a/Tests/sthArgumentCompleter.tests.ps1
+++ b/Tests/sthArgumentCompleter.tests.ps1
@@ -27,7 +27,7 @@ Describe "sthArgumentCompleter" {
         inClearArgumentCompleters
         inCreateTestEnvironment
     }
-    
+
     AfterAll {
         inClearArgumentCompleters
     }
@@ -38,12 +38,12 @@ Describe "sthArgumentCompleter" {
             $CustomArgumentCompleters = Get-CustomArgumentCompleter
             $CustomArgumentCompleters | Should -HaveCount 5
         }
-        
+
         It "Should get Custom Argument Completers by Name" {
             $CustomArgumentCompleters = Get-CustomArgumentCompleter -Name CommandOne:ParameterOne, CommandTwo:ParameterTwo, ParameterThree
             $CustomArgumentCompleters | Should -HaveCount 3
         }
-        
+
         It "Should add type name when ExpandScriptBlocks used" {
             $CustomArgumentCompleters = Get-CustomArgumentCompleter -Name CommandOne:ParameterOne -ExpandScriptBlocks
             $CustomArgumentCompleters.pstypenames[0] | Should -BeExactly 'sth.CustomArgumentCompleter#Expand'
@@ -75,7 +75,7 @@ Describe "sthArgumentCompleter" {
             $ScriptBlock.ToString() | Should -BeExactly " 'Testing-11.' "
         }
 
-        It "Should accept Custom Argument Completer through the pipeline" {
+        It "Should accept Custom Argument Completers from the pipeline" {
             $ScriptBlock = Get-CustomArgumentCompleter -Name CommandOne:ParameterTwo | Get-CustomArgumentCompleterScriptBlock
             $ScriptBlock.ToString() | Should -BeExactly " 'Testing-12.' "
         }
@@ -84,7 +84,7 @@ Describe "sthArgumentCompleter" {
             { Get-CustomArgumentCompleterScriptBlock -Name nonexistentArgumentCompleter -ErrorAction Stop } | Should -Throw -ErrorId 'ArgumentError'
         }
     }
-    
+
     Context "Get-NativeArgumentCompleterScriptBlock" {
         
         It "Should get Native Argument Completer ScriptBlock" {
@@ -92,7 +92,7 @@ Describe "sthArgumentCompleter" {
             $ScriptBlock.ToString() | Should -BeExactly " 'Testing-30.' "
         }
 
-        It "Should accept Native Argument Completer through the pipeline" {
+        It "Should accept Native Argument Completers from the pipeline" {
             $ScriptBlock = Get-NativeArgumentCompleter -Name CommandFour | Get-NativeArgumentCompleterScriptBlock
             $ScriptBlock.ToString() | Should -BeExactly " 'Testing-40.' "
         }
@@ -109,7 +109,7 @@ Describe "sthArgumentCompleter" {
             Get-CustomArgumentCompleter | Should -HaveCount 4
         }
 
-        It "Should accept Custom Argument Completers to delete through the pipeline" {
+        It "Should accept Custom Argument Completers to delete from the pipeline" {
             Get-CustomArgumentCompleter -Name CommandOne:ParameterTwo | Remove-CustomArgumentCompleter
             Get-CustomArgumentCompleter -Name CommandOne:ParameterTwo | Should -BeNullOrEmpty
             Get-CustomArgumentCompleter | Should -HaveCount 3
@@ -127,7 +127,7 @@ Describe "sthArgumentCompleter" {
             Get-NativeArgumentCompleter | Should -HaveCount 2
         }
 
-        It "Should accept Native Argument Completers to delete through the pipeline" {
+        It "Should accept Native Argument Completers to delete from the pipeline" {
             Get-NativeArgumentCompleter -Name CommandFour | Remove-NativeArgumentCompleter
             Get-NativeArgumentCompleter -Name CommandFour | Should -BeNullOrEmpty
             Get-NativeArgumentCompleter | Should -HaveCount 1
@@ -161,7 +161,7 @@ Describe "ArgumentCompleterCompleters" {
         inClearArgumentCompleters
         inCreateTestEnvironment
     }
-    
+
     AfterAll {
         inClearArgumentCompleters
     }

--- a/Tests/sthArgumentCompleter.tests.ps1
+++ b/Tests/sthArgumentCompleter.tests.ps1
@@ -75,16 +75,26 @@ Describe "sthArgumentCompleter" {
             $ScriptBlock.ToString() | Should -BeExactly " 'Testing-11.' "
         }
 
+        It "Should accept Custom Argument Completer through the pipeline" {
+            $ScriptBlock = Get-CustomArgumentCompleter -Name CommandOne:ParameterTwo | Get-CustomArgumentCompleterScriptBlock
+            $ScriptBlock.ToString() | Should -BeExactly " 'Testing-12.' "
+        }
+
         It "Should return an error when Custom Argument Completer doesn't exist" {
             { Get-CustomArgumentCompleterScriptBlock -Name nonexistentArgumentCompleter -ErrorAction Stop } | Should -Throw -ErrorId 'ArgumentError'
         }
     }
-
+    
     Context "Get-NativeArgumentCompleterScriptBlock" {
-
+        
         It "Should get Native Argument Completer ScriptBlock" {
             $ScriptBlock = Get-NativeArgumentCompleterScriptBlock -Name CommandThree
             $ScriptBlock.ToString() | Should -BeExactly " 'Testing-30.' "
+        }
+
+        It "Should accept Native Argument Completer through the pipeline" {
+            $ScriptBlock = Get-NativeArgumentCompleter -Name CommandFour | Get-NativeArgumentCompleterScriptBlock
+            $ScriptBlock.ToString() | Should -BeExactly " 'Testing-40.' "
         }
 
         It "Should return an error when Native Argument Completer doesn't exist" {
@@ -99,7 +109,7 @@ Describe "sthArgumentCompleter" {
             Get-CustomArgumentCompleter | Should -HaveCount 4
         }
 
-        It "Should accept Custom Argument Completers to delete by pipeline" {
+        It "Should accept Custom Argument Completers to delete through the pipeline" {
             Get-CustomArgumentCompleter -Name CommandOne:ParameterTwo | Remove-CustomArgumentCompleter
             Get-CustomArgumentCompleter -Name CommandOne:ParameterTwo | Should -BeNullOrEmpty
             Get-CustomArgumentCompleter | Should -HaveCount 3
@@ -117,7 +127,7 @@ Describe "sthArgumentCompleter" {
             Get-NativeArgumentCompleter | Should -HaveCount 2
         }
 
-        It "Should accept Native Argument Completers to delete by pipeline" {
+        It "Should accept Native Argument Completers to delete through the pipeline" {
             Get-NativeArgumentCompleter -Name CommandFour | Remove-NativeArgumentCompleter
             Get-NativeArgumentCompleter -Name CommandFour | Should -BeNullOrEmpty
             Get-NativeArgumentCompleter | Should -HaveCount 1

--- a/sthArgumentCompleterFunctions.ps1
+++ b/sthArgumentCompleterFunctions.ps1
@@ -61,42 +61,60 @@ function Get-NativeArgumentCompleter
 function Get-CustomArgumentCompleterScriptBlock
 {
     Param (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [ArgumentCompleter([sthCustomArgumentCompleter])]
-        [string]$Name
+        [string[]]$Name
     )
 
-    $argumentCompleters = inGetArgumentCompleter -Type Custom
-    [scriptblock]$scriptBlock = $null
-
-    if ($argumentCompleters.TryGetValue($Name,[ref]$scriptBlock))
+    begin
     {
-        $scriptBlock
+        $argumentCompleters = inGetArgumentCompleter -Type Custom
+        [scriptblock]$scriptBlock = $null
     }
-    else
+
+    process
     {
-        Write-Error -Message "There are no argument completer `"$Name`"." -ErrorId "ArgumentError" -Category InvalidArgument 
+        foreach ($n in $Name)
+        {
+            if ($argumentCompleters.TryGetValue($n,[ref]$scriptBlock))
+            {
+                $scriptBlock
+            }
+            else
+            {
+                Write-Error -Message "There are no argument completer `"$n`"." -ErrorId "ArgumentError" -Category InvalidArgument 
+            }
+        }
     }
 }
 
 function Get-NativeArgumentCompleterScriptBlock
 {
     Param (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [ArgumentCompleter([sthNativeArgumentCompleter])]
-        [string]$Name
+        [string[]]$Name
     )
 
-    $argumentCompleters = inGetArgumentCompleter -Type Native
-    [scriptblock]$scriptBlock = $null
-
-    if ($argumentCompleters.TryGetValue($Name,[ref]$scriptBlock))
+    begin
     {
-        $ScriptBlock
+        $argumentCompleters = inGetArgumentCompleter -Type Native
+        [scriptblock]$scriptBlock = $null
     }
-    else
+
+    process
     {
-        Write-Error -Message "There are no argument completer `"$Name`"." -ErrorId "ArgumentError" -Category InvalidArgument
+        foreach ($n in $Name)
+        {        
+            if ($argumentCompleters.TryGetValue($n,[ref]$scriptBlock))
+            {
+                $ScriptBlock
+            }
+            else
+            {
+                Write-Error -Message "There are no argument completer `"$n`"." -ErrorId "ArgumentError" -Category InvalidArgument
+            }
+        }
     }
 }
 

--- a/sthArgumentCompleterFunctions.ps1
+++ b/sthArgumentCompleterFunctions.ps1
@@ -8,7 +8,7 @@ function Get-CustomArgumentCompleter
 
     $argumentCompleters = inGetArgumentCompleter -Type Custom
 
-    foreach ($a in $argumentCompleters.GetEnumerator())
+    foreach ($a in $($argumentCompleters.GetEnumerator()))
     {
         if ($Name)
         {
@@ -38,7 +38,7 @@ function Get-NativeArgumentCompleter
     
     $argumentCompleters = inGetArgumentCompleter -Type Native
 
-    foreach ($a in $argumentCompleters.GetEnumerator())
+    foreach ($a in $($argumentCompleters.GetEnumerator()))
     {
         if ($Name)
         {
@@ -103,18 +103,24 @@ function Get-NativeArgumentCompleterScriptBlock
 function Remove-CustomArgumentCompleter
 {
     Param (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [ArgumentCompleter([sthCustomArgumentCompleter])]
         [string[]]$Name
     )
 
-    $argumentCompleters = inGetArgumentCompleter -Type Custom
-
-    foreach ($n in $Name)
+    begin
     {
-        if (!$argumentCompleters.Remove($n))
+        $argumentCompleters = inGetArgumentCompleter -Type Custom
+    }
+
+    process
+    {
+        foreach ($n in $Name)
         {
-            Write-Error -Message "There are no argument completer `"$n`"." -ErrorId "ArgumentError" -Category InvalidArgument
+            if (!$argumentCompleters.Remove($n))
+            {
+                Write-Error -Message "There are no argument completer `"$n`"." -ErrorId "ArgumentError" -Category InvalidArgument
+            }
         }
     }
 }
@@ -122,18 +128,24 @@ function Remove-CustomArgumentCompleter
 function Remove-NativeArgumentCompleter
 {
     Param (
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [ArgumentCompleter([sthNativeArgumentCompleter])]
         [string[]]$Name
     )
 
-    $argumentCompleters = inGetArgumentCompleter -Type Native
-
-    foreach ($n in $Name)
+    begin
     {
-        if (!$argumentCompleters.Remove($n))
+        $argumentCompleters = inGetArgumentCompleter -Type Native
+    }
+
+    process
+    {
+        foreach ($n in $Name)
         {
-            Write-Error -Message "There are no argument completer `"$n`"." -ErrorId "ArgumentError" -Category InvalidArgument
+            if (!$argumentCompleters.Remove($n))
+            {
+                Write-Error -Message "There are no argument completer `"$n`"." -ErrorId "ArgumentError" -Category InvalidArgument
+            }
         }
     }
 }

--- a/sthArgumentCompleterFunctions.ps1
+++ b/sthArgumentCompleterFunctions.ps1
@@ -35,7 +35,7 @@ function Get-NativeArgumentCompleter
         [string[]]$Name,
         [switch]$ExpandScriptBlocks
     )
-    
+
     $argumentCompleters = inGetArgumentCompleter -Type Native
 
     foreach ($a in $($argumentCompleters.GetEnumerator()))
@@ -239,7 +239,7 @@ function inCreateArgumentCompleterCustomObject
             ParameterName = $parameterName
             ScriptBlock = $argumentCompleter.Value
         } | Add-Member -TypeName 'sth.CustomArgumentCompleter' -PassThru
-    
+
         if ($ExpandScriptBlocks)
         {
             $object | Add-Member -TypeName 'sth.CustomArgumentCompleter#Expand'
@@ -252,7 +252,7 @@ function inCreateArgumentCompleterCustomObject
             CommandName = $argumentCompleter.Key
             ScriptBlock = $argumentCompleter.Value
         } | Add-Member -TypeName 'sth.NativeArgumentCompleter' -PassThru
-    
+
         if ($ExpandScriptBlocks)
         {
             $object | Add-Member -TypeName 'sth.NativeArgumentCompleter#Expand'

--- a/sthArgumentCompleterFunctions.ps1
+++ b/sthArgumentCompleterFunctions.ps1
@@ -204,6 +204,7 @@ function inCreateArgumentCompleterCustomObject
         }
 
         $object = [PSCustomObject]@{
+            Name = $argumentCompleter.Key
             CommandName = $commandName
             ParameterName = $parameterName
             ScriptBlock = $argumentCompleter.Value
@@ -217,6 +218,7 @@ function inCreateArgumentCompleterCustomObject
     else
     {
         $object = [PSCustomObject]@{
+            Name = $argumentCompleter.Key
             CommandName = $argumentCompleter.Key
             ScriptBlock = $argumentCompleter.Value
         } | Add-Member -TypeName 'sth.NativeArgumentCompleter' -PassThru


### PR DESCRIPTION
Add:
- Name property to the `sth.CustomArgumentCompleter` and `sth.NativeArgumentCompleter` custom objects.
- Pipeline support to `Remove-*ArgumentCompleter` and `Get-*ArgumentCompleterSctiptBlock` functions.
- Add respective tests.